### PR TITLE
Fix mismatched parentheses in utils.py

### DIFF
--- a/utils.py
+++ b/utils.py
@@ -59,7 +59,7 @@ def fix_symbol(exchange_id, symbol):
     """
     result = symbol.upper().replace('-', '/')
     # Replace USD with USDT
-    if exchange_id in USDT_EXCHANGE_IDS and (result.endswith('/USD' or result.endswith('/EUR'))):
+    if exchange_id in USDT_EXCHANGE_IDS and (result.endswith('/USD') or result.endswith('/EUR')):
         result = result.replace('/USD', '/USDT')
         result = result.replace('/EUR', '/EURT')
     return result


### PR DESCRIPTION
Hi there!
While [scanning a punch of Python code](https://semgrep.live/scan/26523a72-8d8a-4fcf-81ff-eb33178cd4ec), I noticed some imbalanced parentheses in your code.

The actual scan finding looks for anyone using strings in Python with boolean operators like `and` and `or` -- using strings in this way often doesn't do what is expected.

```python
>>> d = {'a': 1, 'b': 2}
>>> 'a' and 'b' in d
True
>>> 'a' in d
True
>>> 'a' and 'b'
'b'
>>> 'b' in d
True
>>> 'b' and 'c' in d
False
>>> 'c' and 'b' in d
True
>>> 'zip' or 'pkg'
'zip'
>>> 
```

However, this scanner detected something else in your code, identifying what looks like mismatched parentheses in utils.py. This PR puts the parentheses in the right places.

Anyway, hope this helps! If you're interested in scanning your code for more issues, check out https://semgrep.live!
Cheers!